### PR TITLE
Fix warning 244

### DIFF
--- a/mdialog.inc
+++ b/mdialog.inc
@@ -802,12 +802,11 @@ static stock _MDialog_ProcessTags(const info[], result_info[], const size = size
 		j;
 
 	for (i = 0; i < lines_count; i++) {
-		if (tag_line[i] == E_MDIALOG_TAG_NONE) {
-			continue;
-		}
-
 		// get spaces count by tag
 		switch (tag_line[i]) {
+			case E_MDIALOG_TAG_NONE: {
+				continue;
+			}
 			case E_MDIALOG_TAG_CENTER: {
 				spaces = floatround((max_size - line_sizes[i]) / 2.0 / gCharSize[' ']);
 			}


### PR DESCRIPTION
Fixes a `warning 244: enum element "E_MDIALOG_TAG_NONE" not handled in switch` message.
This message is not shown when using the current latest version of the compiler (3.10.10), but the underlying diagnostic is going to be included in the 3.10.11 release, so it's better to prepare in advance.