### PR TITLE
Fix potential recursion

### DIFF
--- a/mdialog.inc
+++ b/mdialog.inc
@@ -498,7 +498,7 @@ stock Dialog_Close(playerid, const function[] = "", showDialog = true)
 	Dialog_Interrupt(playerid, function);
 
 	if (showDialog) {
-		return ShowPlayerDialog(playerid, -1, DIALOG_STYLE_MSGBOX, " ", " ", " ", "");
+		return MDialogFix_ShowPlayerDialog(playerid, -1, DIALOG_STYLE_MSGBOX, " ", " ", " ", "");
 	}
 
 	return 1;


### PR DESCRIPTION
Fixes the `MDialogFix_ShowPlayerDialog() => Dialog_Close() => MDialogFix_ShowPlayerDialog()` recursion, originally reported by @JustDeimos (#17).
While I don't think this recursion can be achieved in real use (hence the "potential" in the title), the compiler still detects it with the `-R` option, so I believe it would be better to have it fixed.